### PR TITLE
Build under Go 1.9.2 and other minor fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: false
 language: go
 
+go:
+    - 1.9.2
+
 matrix:
   include:
     - os: osx

--- a/fsevents.go
+++ b/fsevents.go
@@ -150,6 +150,9 @@ func (r *eventStreamRegistry) Delete(i uintptr) {
 
 // Start listening to an event stream.
 func (es *EventStream) Start() {
+	if es.Events == nil {
+		es.Events = make(chan []Event)
+	}
 
 	// register eventstream in the local registry for later lookup
 	// in C callback
@@ -159,9 +162,6 @@ func (es *EventStream) Start() {
 		es.uuid = GetDeviceUUID(es.Device)
 	}
 	es.start(es.Paths, cbInfo)
-	if es.Events == nil {
-		es.Events = make(chan []Event)
-	}
 }
 
 // Flush events that have occurred but haven't been delivered.

--- a/fsevents.go
+++ b/fsevents.go
@@ -155,7 +155,9 @@ func (es *EventStream) Start() {
 	// in C callback
 	cbInfo := registry.Add(es)
 	es.registryID = cbInfo
-	es.uuid = GetDeviceUUID(es.Device)
+	if es.Device != 0 {
+		es.uuid = GetDeviceUUID(es.Device)
+	}
 	es.start(es.Paths, cbInfo)
 	if es.Events == nil {
 		es.Events = make(chan []Event)

--- a/fsevents_test.go
+++ b/fsevents_test.go
@@ -1,3 +1,32 @@
 // +build darwin
 
 package fsevents
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestBasicExample(t *testing.T) {
+	path, err := ioutil.TempDir("", "fsexample")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(path)
+
+	dev, err := DeviceForPath(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	es := &EventStream{
+		Paths:   []string{path},
+		Latency: 500 * time.Millisecond,
+		Device:  dev,
+		Flags:   FileEvents,
+	}
+
+	es.Start()
+}

--- a/fsevents_test.go
+++ b/fsevents_test.go
@@ -5,6 +5,7 @@ package fsevents
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -29,4 +30,23 @@ func TestBasicExample(t *testing.T) {
 	}
 
 	es.Start()
+
+	wait := make(chan Event)
+	go func() {
+		for msg := range es.Events {
+			for _, event := range msg {
+				t.Logf("Event: %#v", event)
+				wait <- event
+				es.Stop()
+				return
+			}
+		}
+	}()
+
+	err = ioutil.WriteFile(filepath.Join(path, "example.txt"), []byte("example"), 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	<-wait
 }

--- a/wrap.go
+++ b/wrap.go
@@ -35,7 +35,7 @@ import (
 )
 
 // eventIDSinceNow is a sentinel to begin watching events "since now".
-const eventIDSinceNow = uint64(C.kFSEventStreamEventIdSinceNow + (1 << 64))
+const eventIDSinceNow = uint64(C.kFSEventStreamEventIdSinceNow)
 
 // LatestEventID returns the most recently generated event ID, system-wide.
 func LatestEventID() uint64 {


### PR DESCRIPTION
This pull request incorporates 3 fixes to fsevents:

- Fix uint64 overflow during build by remove unnecessary (1 << 64) to kFSEventStreamEventIdSinceNow flag.

- Avoid assertion failed error message when requesting a Host Stream (device id = 0).

- Fix race condition in channel creation (cherry-picked from fsnotify/fsevents#29)

Fixes elastic/beats#5783